### PR TITLE
User Authentication

### DIFF
--- a/portfolio/src/main/java/com/google/sps/data/EntityProperties.java
+++ b/portfolio/src/main/java/com/google/sps/data/EntityProperties.java
@@ -10,9 +10,6 @@ public final class EntityProperties {
   /** The property representing the text of a comment on the webpage. */
   public static final String COMMENT_TEXT = "text";
 
-  /** The property representing the user id of the author of a comment. */
-  public static final String USER_ID_OF_AUTHOR = "userId";
-
   /** The property representing the timestamp when the comment was posted (in 
     * milliseconds since the epoch). */
   public static final String COMMENT_TIMESTAMP = "time";
@@ -24,11 +21,16 @@ public final class EntityProperties {
   /** The property representing the email of the author of this comment */
   public static final String USER_EMAIL = "email";
 
-  /* User Properties */
-
-  /** The property representing the user id */
-  public static final String USER_ID = "userId";
+  /* User Properties: */
 
   /** The property representing the username of this user */
   public static final String USERNAME = "username";
+
+  /* Both User and Comment properties: */
+
+  /** 
+    * The property representing the user id of a user or an author 
+    * of a comment. 
+    */
+  public static final String USER_ID = "userId";
 }

--- a/portfolio/src/main/java/com/google/sps/data/EntityProperties.java
+++ b/portfolio/src/main/java/com/google/sps/data/EntityProperties.java
@@ -5,13 +5,13 @@ public final class EntityProperties {
 
   private EntityProperties() {}
 
-  /* Entity Properties: */
+  /* Comment Properties: */
 
   /** The property representing the text of a comment on the webpage. */
   public static final String COMMENT_TEXT = "text";
 
-  /** The property representing the name of the author of a comment. */
-  public static final String COMMENT_AUTHOR = "name";
+  /** The property representing the user id of the author of a comment. */
+  public static final String USER_ID_OF_AUTHOR = "userId";
 
   /** The property representing the timestamp when the comment was posted (in 
     * milliseconds since the epoch). */
@@ -20,4 +20,12 @@ public final class EntityProperties {
   /** The property representing the numeric id of this entiity in the 
     * datastore. Used for deleting comments. */
   public static final String COMMENT_ID = "id";
+
+  /* User Properties */
+
+  /** The property representing the user id */
+  public static final String USER_ID = "userId";
+
+  /** The property representing the username of this user */
+  public static final String USERNAME = "username";
 }

--- a/portfolio/src/main/java/com/google/sps/data/EntityProperties.java
+++ b/portfolio/src/main/java/com/google/sps/data/EntityProperties.java
@@ -21,6 +21,9 @@ public final class EntityProperties {
     * datastore. Used for deleting comments. */
   public static final String COMMENT_ID = "id";
 
+  /** The property representing the email of the author of this comment */
+  public static final String USER_EMAIL = "email";
+
   /* User Properties */
 
   /** The property representing the user id */

--- a/portfolio/src/main/java/com/google/sps/data/EntityProperties.java
+++ b/portfolio/src/main/java/com/google/sps/data/EntityProperties.java
@@ -16,4 +16,8 @@ public final class EntityProperties {
   /** The property representing the timestamp when the comment was posted (in 
     * milliseconds since the epoch). */
   public static final String COMMENT_TIMESTAMP = "time";
+
+  /** The property representing the numeric id of this entiity in the 
+    * datastore. Used for deleting comments. */
+  public static final String COMMENT_ID = "id";
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/AuthenticationServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/AuthenticationServlet.java
@@ -1,0 +1,70 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sps.servlets;
+
+import java.io.IOException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.ArrayList;
+import java.util.List;
+import com.google.gson.Gson;
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.Key;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.Query.SortDirection;
+import java.lang.Math;
+import com.google.common.base.Strings;
+import com.google.common.collect.Range;
+import com.google.sps.data.EntityProperties;
+import com.google.sps.data.RequestParameters;
+import java.util.stream.Collectors;
+import com.google.appengine.api.users.UserService;
+import com.google.appengine.api.users.UserServiceFactory;
+import java.util.HashMap;
+
+/** 
+  * Servlet that uploads and retrieves persistent comment data using datastore.
+  */
+@WebServlet("/authenticate")
+public class AuthenticationServlet extends HttpServlet {
+
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    UserService userService = UserServiceFactory.getUserService();
+    HashMap<String, Object> authenticationStatusInfo = 
+      new HashMap<String, Object>();
+
+    if (userService.isUserLoggedIn()) {
+      authenticationStatusInfo.put("isLoggedIn", true);
+      String logOutLink = userService.createLogoutURL("/index.html");
+      authenticationStatusInfo.put("logOutLink", logOutLink);
+    } else {
+      authenticationStatusInfo.put("isLoggedIn", false);
+      String logInLink = userService.createLoginURL("/index.html");
+      authenticationStatusInfo.put("logInLink", logInLink);
+    }
+
+    String json = (new Gson()).toJson(authenticationStatusInfo);
+    System.out.println(json);
+    response.setContentType("application/json;");
+    response.getWriter().println(json);
+  }
+
+}

--- a/portfolio/src/main/java/com/google/sps/servlets/AuthenticationServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/AuthenticationServlet.java
@@ -47,7 +47,7 @@ public class AuthenticationServlet extends HttpServlet {
 
   /** 
     * Checks whether the user is currently logged in and provides
-    * a log-in link if not, and a log-out link if not. 
+    * a log-out link and username if so, and a log-in link if not. 
     */
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -263,7 +263,8 @@ public class DataServlet extends HttpServlet {
     if (Strings.isNullOrEmpty(search)) {
       return true;
     } else {
-      return comment.text.contains(search) || comment.username.contains(search);
+      return comment.text.contains(search) || 
+        comment.username.contains(search) || comment.email.contains(search);
     }
   }
 

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -137,6 +137,8 @@ public class DataServlet extends HttpServlet {
     String currentUserId;
     if (!userService.isUserLoggedIn()) {
       currentUserId = "";
+    } else if (userService.isUserAdmin()) {
+      currentUserId = "ADMIN";
     } else {
       currentUserId = userService.getCurrentUser().getUserId();
     }

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -53,13 +53,16 @@ public class DataServlet extends HttpServlet {
       long time;
       long id;
       String userId;
+      String email;
 
-      Comment(String text, String username, long time, long id, String userId) {
+      Comment(String text, String username, long time, long id, 
+        String userId, String email) {
         this.text = text;
         this.username = username;
         this.time = time;
         this.id = id;
         this.userId = userId;
+        this.email = email;
       }
 
       /** Returns an entity representing this comment. */
@@ -68,6 +71,7 @@ public class DataServlet extends HttpServlet {
         commentEntity.setProperty(EntityProperties.COMMENT_TEXT, text);
         commentEntity.setProperty(EntityProperties.COMMENT_TIMESTAMP, time);
         commentEntity.setProperty(EntityProperties.USER_ID_OF_AUTHOR, userId);
+        commentEntity.setProperty(EntityProperties.USER_EMAIL, email);
         return commentEntity;
       }
 
@@ -79,7 +83,8 @@ public class DataServlet extends HttpServlet {
             (String) e.getProperty(EntityProperties.USER_ID_OF_AUTHOR)),
           (long) e.getProperty(EntityProperties.COMMENT_TIMESTAMP), 
           e.getKey().getId(),
-          (String) e.getProperty(EntityProperties.USER_ID_OF_AUTHOR));
+          (String) e.getProperty(EntityProperties.USER_ID_OF_AUTHOR),
+          (String) e.getProperty(EntityProperties.USER_EMAIL));
       }
   }
 
@@ -101,13 +106,15 @@ public class DataServlet extends HttpServlet {
     }
     long timestamp = System.currentTimeMillis();
     String userId = userService.getCurrentUser().getUserId();
+    String email = userService.getCurrentUser().getEmail();
     AuthenticationServlet.updateUserName(userName, userId);
 
     if (!Strings.isNullOrEmpty(userComment)) {    
       DatastoreService datastore = 
         DatastoreServiceFactory.getDatastoreService();
       Key key = datastore.put(
-        (new Comment(userComment, "", timestamp, 0, userId)).toEntity());
+        (new Comment(userComment, "", timestamp, 0, userId, email))
+        .toEntity());
       try {
         Entity commentJustAdded = datastore.get(key);
         commentJustAdded.setProperty(EntityProperties.COMMENT_ID, key.getId());

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -133,6 +133,14 @@ public class DataServlet extends HttpServlet {
     */
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    UserService userService = UserServiceFactory.getUserService();
+    String currentUserId;
+    if (!userService.isUserLoggedIn()) {
+      currentUserId = "";
+    } else {
+      currentUserId = userService.getCurrentUser().getUserId();
+    }
+
     int numberToDisplay = getNumberToDisplay(request); 
     String paginationInstruction = (String) request.getParameter(
       RequestParameters.PAGE_ACTION);
@@ -157,7 +165,8 @@ public class DataServlet extends HttpServlet {
       commentRange.upperEndpoint());
     int newPageToken = commentRange.lowerEndpoint();
 
-    String json = convertToJson(commentsToDisplay, newPageToken); 
+    String json = convertToJson(commentsToDisplay, newPageToken, 
+      currentUserId); 
     response.setContentType("application/json;");
     response.getWriter().println(json);
   }
@@ -256,11 +265,16 @@ public class DataServlet extends HttpServlet {
     }
   }
 
-  /** Returns JSON string representation of `data`. */
-  private String convertToJson(List<Comment> data, int pageToken) {
-    List<Object> combineData = new ArrayList<Object>();
-    combineData.add(pageToken);
-    combineData.add(data);
+  /** 
+    * Returns JSON string representation of `data`, `pageToken`, 
+    * and `currentUserId`. 
+    */
+  private String convertToJson(List<Comment> data, int pageToken, 
+    String currentUserId) {
+    HashMap<String, Object> combineData = new HashMap<String, Object>();
+    combineData.put("pageToken", pageToken);
+    combineData.put("commentData", data);
+    combineData.put("currentUserId", currentUserId);
 
     Gson gson = new Gson(); 
     String json = gson.toJson(combineData);

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -70,7 +70,7 @@ public class DataServlet extends HttpServlet {
         Entity commentEntity = new Entity("Comment");
         commentEntity.setProperty(EntityProperties.COMMENT_TEXT, text);
         commentEntity.setProperty(EntityProperties.COMMENT_TIMESTAMP, time);
-        commentEntity.setProperty(EntityProperties.USER_ID_OF_AUTHOR, userId);
+        commentEntity.setProperty(EntityProperties.USER_ID, userId);
         commentEntity.setProperty(EntityProperties.USER_EMAIL, email);
         return commentEntity;
       }
@@ -80,10 +80,10 @@ public class DataServlet extends HttpServlet {
         return new Comment(
           (String) e.getProperty(EntityProperties.COMMENT_TEXT),
           AuthenticationServlet.getUserName(
-            (String) e.getProperty(EntityProperties.USER_ID_OF_AUTHOR)),
+            (String) e.getProperty(EntityProperties.USER_ID)),
           (long) e.getProperty(EntityProperties.COMMENT_TIMESTAMP), 
           e.getKey().getId(),
-          (String) e.getProperty(EntityProperties.USER_ID_OF_AUTHOR),
+          (String) e.getProperty(EntityProperties.USER_ID),
           (String) e.getProperty(EntityProperties.USER_EMAIL));
       }
   }

--- a/portfolio/src/main/java/com/google/sps/servlets/DeleteServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DeleteServlet.java
@@ -29,6 +29,7 @@ import com.google.appengine.api.datastore.PreparedQuery;
 import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.datastore.Query.SortDirection;
 import com.google.sps.data.RequestParameters;
+import com.google.sps.data.EntityProperties;
 
 /** Servlet that deletes all persistent comment data from datastore. */
 @WebServlet("/delete-data")

--- a/portfolio/src/main/java/com/google/sps/servlets/DeleteServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DeleteServlet.java
@@ -58,7 +58,8 @@ public class DeleteServlet extends HttpServlet {
       PreparedQuery results = datastore.prepare(query);
       results.asIterable().forEach(comment -> {
         if (currentUserId.equals((String) comment.getProperty(
-          EntityProperties.USER_ID_OF_AUTHOR))) {
+          EntityProperties.USER_ID_OF_AUTHOR)) || 
+          userService.isUserAdmin()) {
           datastore.delete(comment.getKey());
         }
       });

--- a/portfolio/src/main/java/com/google/sps/servlets/DeleteServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DeleteServlet.java
@@ -58,7 +58,7 @@ public class DeleteServlet extends HttpServlet {
       PreparedQuery results = datastore.prepare(query);
       results.asIterable().forEach(comment -> {
         if (currentUserId.equals((String) comment.getProperty(
-          EntityProperties.USER_ID_OF_AUTHOR)) || 
+          EntityProperties.USER_ID)) || 
           userService.isUserAdmin()) {
           datastore.delete(comment.getKey());
         }

--- a/portfolio/src/main/java/com/google/sps/servlets/DeleteServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DeleteServlet.java
@@ -43,20 +43,19 @@ public class DeleteServlet extends HttpServlet {
       (String) request.getParameter(RequestParameters.WHICH_COMMENT_TO_DELETE);
 
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
-    Query query = new Query("Comment");
-    PreparedQuery results = datastore.prepare(query);
 
     if (whichCommentToDelete.equals("\"all\"")) {
+      Query query = new Query("Comment");
+      PreparedQuery results = datastore.prepare(query);
       results.asIterable().forEach(comment -> {
         datastore.delete(comment.getKey());
       });
     } else {
-      Long id = Long.parseLong(whichCommentToDelete);
-      results.asIterable().forEach(comment -> {
-        if (comment.getKey().getId() == id) {
-          datastore.delete(comment.getKey());
-        }
-      });
+      long id = Long.parseLong(whichCommentToDelete);
+      Query query = new Query("Comment").setFilter(new Query.FilterPredicate
+        (EntityProperties.COMMENT_ID, Query.FilterOperator.EQUAL, id));
+      Entity commentWithCorrectId = datastore.prepare(query).asSingleEntity();
+      datastore.delete(commentWithCorrectId.getKey());
     }
   }
 

--- a/portfolio/src/main/java/com/google/sps/servlets/DeleteServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DeleteServlet.java
@@ -30,6 +30,7 @@ import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.datastore.Query.SortDirection;
 import com.google.sps.data.RequestParameters;
 import com.google.sps.data.EntityProperties;
+import com.google.sps.servlets.AuthenticationServlet;
 
 /** Servlet that deletes all persistent comment data from datastore. */
 @WebServlet("/delete-data")

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -112,21 +112,8 @@
                         <button onclick="onClearSearch()">X</button>
                     </td>
                 </tr>
-                <tr>
-                    <td id="leave-a-comment" colspan="7">
-                        Leave a comment:
-                    </td>
-                </tr> 
             </table>
-            <div id="comment-form-box">
-            <form action="/data" method="POST" id="comment-form">
-                <input type="text" name="author" id="author" value="" 
-                    tabindex="1" required="required" placeholder="Name">
-                <textarea name="text-input" id="text-input" rows="10" 
-                    tabindex="4" required="required"></textarea>
-                <input type="submit" />
-            </form>
-            </div>
+            <div id="comment-form"></div>
         </div>
     </div>
 </body>

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -262,7 +262,7 @@ function getCommentHTML(currentUserId, json, i) {
       in question. 
   */
 function getCommentButtonHTML(currentUserId, commentObject) {
-  if (currentUserId === commentObject.userId) {
+  if (currentUserId === commentObject.userId || currentUserId === "ADMIN") {
     return `<button onclick="deleteThisComment(${commentObject.id})">` +
       `X</button>`;
   } else {

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -19,6 +19,40 @@ let pageToken = 0;
 function onLoad() {
   displayCommentSection('none');
   initializeSearchBar();
+  fetch(`/authenticate`)
+  .then(response => response.json())
+  .then(displayCommentForm);
+}
+
+/** Determines whether the current user is signed in, and if so, 
+  * displays the form where the user could leave a comment. If
+  * not, it displays a link to sign in.
+  * @param json The json returned by the GET request to /authenticate  */
+function displayCommentForm(json) {
+  let commentFormBox = document.getElementById("comment-form");
+  if (json.isLoggedIn) {
+    commentFormBox.innerHTML = 
+      `<table>` +
+          `<tr>` +
+              `<td id="leave-a-comment">` +
+                  `Leave a comment:` +
+              `</td>` +
+          `</tr>` + 
+      `</table>` +
+      `<div id="comment-form-box">` +
+        `<form action="/data" method="POST" id="comment-form">` +
+            `<input type="text" name="author" id="author" value=""` +
+                `tabindex="1" required="required" placeholder="Name">` +
+            `<textarea name="text-input" id="text-input" rows="10"` + 
+                `tabindex="4" required="required"></textarea>` +
+            `<input type="submit" />` +
+        `</form>` +
+      `</div>` +
+      `<div id="log-out"><a href="${json.logOutLink}">Log out</a> here.`;
+  } else {
+    commentFormBox.innerHTML = `<div id="please-sign-in">Please` +
+      ` <a href="${json.logInLink}">sign in</a> to leave a comment.</div>`
+  }
 }
 
 /** 

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -26,10 +26,13 @@ function onLoad() {
 
 /** Determines whether the current user is signed in, and if so, 
   * displays the form where the user could leave a comment. If
-  * not, it displays a link to sign in.
+  * not, it displays a link to sign in and gets rid of the clear
+  * all button.
   * @param json The json returned by the GET request to /authenticate  */
 function displayCommentForm(json) {
   let commentFormBox = document.getElementById("comment-form");
+  let clearAllButtonBox = document.getElementById("clear-all-button");
+
   if (json.isLoggedIn) {
     const username = !json.username.trim() ? 
       `placeholder="Please enter a username."` : `value="${json.username}"`;
@@ -52,6 +55,7 @@ function displayCommentForm(json) {
       `</div>` +
       `<div id="log-out"><a href="${json.logOutLink}">Log out</a> here.`;
   } else {
+    clearAllButtonBox.innerHTML = ``;
     commentFormBox.innerHTML = `<div id="please-sign-in">Please` +
       ` <a href="${json.logInLink}">sign in</a> to leave a comment.</div>`
   }

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -241,7 +241,7 @@ function getCommentHTML(json, i) {
     ` <td class="comment-button">` + 
     `   <button onclick="deleteThisComment(${json[i].id})">X</button></td>` +
     ` <td colspan = 2 class="user-info-box">` +
-    `   <b><u>${json[i].username}: </b></u><br>` +
+    `   <b><abbr title="${json[i].email}">${json[i].username}</abbr>:</b><br>` +
     `   <i class="comment-date">${prettyPrintTime(json[i].time)}</i>` +
     ` </td>` +
     ` <td colspan="4">` +

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -31,6 +31,8 @@ function onLoad() {
 function displayCommentForm(json) {
   let commentFormBox = document.getElementById("comment-form");
   if (json.isLoggedIn) {
+    const username = !json.username.trim() ? 
+      `placeholder="Please enter a username."` : `value="${json.username}"`;
     commentFormBox.innerHTML = 
       `<table>` +
           `<tr>` +
@@ -41,8 +43,8 @@ function displayCommentForm(json) {
       `</table>` +
       `<div id="comment-form-box">` +
         `<form action="/data" method="POST" id="comment-form">` +
-            `<input type="text" name="author" id="author" value=""` +
-                `tabindex="1" required="required" placeholder="Name">` +
+            `<input type="text" name="author" id="author" ` +
+                `tabindex="1" required="required" ${username}>` +
             `<textarea name="text-input" id="text-input" rows="10"` + 
                 `tabindex="4" required="required"></textarea>` +
             `<input type="submit" />` +
@@ -239,7 +241,7 @@ function getCommentHTML(json, i) {
     ` <td class="comment-button">` + 
     `   <button onclick="deleteThisComment(${json[i].id})">X</button></td>` +
     ` <td colspan = 2 class="user-info-box">` +
-    `   <b><u>${json[i].name}: </b></u><br>` +
+    `   <b><u>${json[i].username}: </b></u><br>` +
     `   <i class="comment-date">${prettyPrintTime(json[i].time)}</i>` +
     ` </td>` +
     ` <td colspan="4">` +

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -199,8 +199,9 @@ function displayCommentSection(pageAction) {
   * @param {JSON} json The JSON representing the list of comment objects. 
   */
 function displayJSON(json) {
-  pageToken = json[0];
-  json = json[1];
+  pageToken = json.pageToken;
+  const currentUserId = json.currentUserId;
+  json = json.commentData;
 
   const dataContainer = document.getElementById('comment-section');
   htmlToAdd =`<table> <tr><td></td><td></td><td></td>` +
@@ -221,7 +222,7 @@ function displayJSON(json) {
       `</tr>`;
   } else {
     let allCommentHTML = [...Array(json.length).keys()]
-      .map(i => getCommentHTML(json, i));
+      .map(i => getCommentHTML(currentUserId, json, i));
     allCommentHTML.forEach(commentHTML => htmlToAdd += commentHTML);
   }
 
@@ -235,11 +236,12 @@ function displayJSON(json) {
   * @param {JSON} json The JSON representing the list of all comments.
   * @param {int} i The index of the desired comment.
   * @return {String} The HTML representation. */
-function getCommentHTML(json, i) {
+function getCommentHTML(currentUserId, json, i) {
   html =
     `<tr>` +
-    ` <td class="comment-button">` + 
-    `   <button onclick="deleteThisComment(${json[i].id})">X</button></td>` +
+    ` <td class="comment-button">` +
+    `   ${getCommentButtonHTML(currentUserId, json[i])}` + 
+    ` </td>` +
     ` <td colspan = 2 class="user-info-box">` +
     `   <b><abbr title="${json[i].email}">${json[i].username}</abbr>:</b><br>` +
     `   <i class="comment-date">${prettyPrintTime(json[i].time)}</i>` +
@@ -249,6 +251,23 @@ function getCommentHTML(json, i) {
     ` </td>` +
     `</tr>`;
   return html;
+}
+
+/** 
+  * Returns the HTML for a button that will delete this comment if
+  * this comment was written by the current user. Otherwise it
+  * returns no button. 
+  * @param {String} currentUserId the id of the current user.
+  * @param {JSON} commentObject the json object representing the comment 
+      in question. 
+  */
+function getCommentButtonHTML(currentUserId, commentObject) {
+  if (currentUserId === commentObject.userId) {
+    return `<button onclick="deleteThisComment(${commentObject.id})">` +
+      `X</button>`;
+  } else {
+    return ``;
+  }
 }
 
 /**

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -366,3 +366,18 @@ select:hover {
     background-color: rgba(255, 255, 255, 0.54);
     cursor: pointer;
 }
+
+#please-sign-in {
+    padding: 15px;
+    font-size: 20px;
+    text-align: center;
+}
+
+#please-sign-in a, #log-out a  {
+    color: black;
+}
+
+#log-out {
+    font-size: 15px;
+    padding: 15px;
+}


### PR DESCRIPTION
Users now have to sign in to post comments. While signed in, they can delete only their own comments individually by hitting the "X" button, or clear all of their own comments by hitting "clear all" (if the user is not signed in, no "clear all" button will appear). Admin users can delete any comments. Once they set a username on the webpage, the server remembers it and will automatically fill the "name" box for the comment form. If the user edits this box while submitting a comment, their username will change for all of their past comments. If you hover over the username in a user's comment, their email will be displayed (you can also search the comment section for email addresses with the search feature). 

(I also added a small change to optimize my comment deletion a bit---before, I was getting all the comments and iterating through every single one in order to delete an individual comment. I recently learned a way to optimize this so that I can retrieve only the comment I'm looking for from the database, by filtering my query. This necessitated adding an "id" property to my Comment entities.)
