### PR TITLE
Optimized Optional Attendees

### DIFF
--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -24,14 +24,46 @@ import java.util.Set;
 import java.util.HashSet;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.Comparator;
+
 
 public final class FindMeetingQuery {
   /** 
+    * If possible, returns all possible time ranges in which the mandatory and 
+    * optional attendees of the requested meeting could meet for the requested 
+    * duration, without conflicting with any `events` that are already scheduled 
+    * for these attendees. If no times are possible that work for all the attendees,
+    * returns possible times such that all mandatory attendees and as many 
+    * optional antendees as possible can attend the meeting at these times. 
+    */
+  public Collection<TimeRange> query(Collection<Event> events, 
+    MeetingRequest request) {
+    Set<String> mandatoryAttendees = request.getAttendees().stream()
+      .collect(Collectors.toSet()); 
+    Set<String> optionalAttendees = request.getOptionalAttendees().stream()
+      .collect(Collectors.toSet());
+    Set<String> allAttendees = Sets.union(mandatoryAttendees, optionalAttendees);
+    
+    Collection<TimeRange> timesIncludingAllAttendees = getPossibleTimes(
+      events, allAttendees, request);
+    if (timesIncludingAllAttendees.isEmpty()) {
+      return getOptimalSubsetTimes(
+          mandatoryAttendees, optionalAttendees, events,request);
+    } else {
+      return timesIncludingAllAttendees; 
+    }
+  }
+
+  /** 
     * Returns all possible time ranges in which the `requestedAttendees`
     * could meet for the requested duration without conflicting with the 
-    * `events` that are already scheduled for these attendees. 
+    * `events` that are already scheduled for these attendees. Returns
+    * possible time ranges in order of start time. 
     */
-  private Collection<TimeRange> getPossibleTimes(Collection<Event> events, 
+  private List<TimeRange> getPossibleTimes(Collection<Event> events, 
     Set<String> requestedAttendees, MeetingRequest request) {
     List<TimeRange> sortedEvents = events.stream()
       .filter(event -> 
@@ -62,77 +94,84 @@ public final class FindMeetingQuery {
   private Collection<TimeRange> getOptimalSubsetTimes(
     Set<String> mandatoryAttendees, Set<String> optionalAttendees, 
     Collection<Event> events, MeetingRequest request) {
-    
-    Set<Set<String>> subsets = Sets.powerSet(optionalAttendees);
-    Set<Set<String>> infeasibleGroups = new HashSet<Set<String>>();
-    Collection<TimeRange> optimalListOfTimes = new ArrayList<TimeRange>();
+    Map<String, List<TimeRange>> mapOfPeopleToTimes = mapPeopleToUnavailabeTImes(events);
+    List<TimeRange> mandatoryAttendeeAvailability = 
+      getPossibleTimes(events, mandatoryAttendees, request);
+    Set<String> mostOptionalAttendeesCanAttend = new HashSet<String>();
 
-    for (int i = 1; i < optionalAttendees.size(); i++) {
-      int currentSizeOfSubsetsToCheck = i;
-      Set<Set<String>> subsetsToCheck = Sets.filter(subsets, subset -> 
-        subset.size() == currentSizeOfSubsetsToCheck && 
-          !containsInfeasibleGroup(subset, infeasibleGroups));
-      if (subsetsToCheck.isEmpty()) {
-        // all subsets larger than this will be infeasible 
-        break;
-      }
-
-      for (Set<String> subset : subsetsToCheck) {
-        Collection<TimeRange> possibleTimes = 
-          getPossibleTimes(events, Sets.union(mandatoryAttendees, subset), request);
-        if (possibleTimes.isEmpty()) {
-          // for any group of optional people containing this group, no meeting 
-          // can be scheduled.
-          infeasibleGroups.add(subset);
-        } else {
-          optimalListOfTimes = possibleTimes;
+    for (TimeRange availableTime : mandatoryAttendeeAvailability) {
+      int start = availableTime.start();
+      int end = start + (int) request.getDuration();
+      while (end <= availableTime.end()) {
+        Set<String> availableOptionalAttendees = getAvailableAttendees(
+          mapOfPeopleToTimes, start, end, optionalAttendees);
+        if (availableOptionalAttendees.size() > mostOptionalAttendeesCanAttend.size()) {
+          mostOptionalAttendeesCanAttend = availableOptionalAttendees;
         }
+        start += 1;
+        end += 1;
       }
     }
 
-    if (optimalListOfTimes.isEmpty() && !mandatoryAttendees.isEmpty()) {
-      return getPossibleTimes(events, mandatoryAttendees, request);
+    if (mandatoryAttendees.isEmpty() && mostOptionalAttendeesCanAttend.isEmpty()) {
+      return new ArrayList();
     } else {
-      return optimalListOfTimes;
+      return getPossibleTimes(
+        events, Sets.union(mandatoryAttendees, mostOptionalAttendeesCanAttend), request);
     }
-
   }
 
   /** 
-    * Returns true if `set` contains a group of people that has already been 
-    * determined to have no mutually open timeslots between the group members 
-    * and the mandatory meeting participants. 
+    * Returns the attendees that are available for the entirety of the time 
+    * range from start to end. Mutates mapOfPeopleToTimes by removing times 
+    * that finish before start. 
     */
-  private boolean containsInfeasibleGroup(Set<String> set, 
-    Set<Set<String>> infeasibleGroups) {
-    return infeasibleGroups.stream().reduce(false, (accumulator, infeasibleGroup) -> {
-      return accumulator || set.containsAll(infeasibleGroup);
-    }, Boolean::logicalOr);
+  private Set<String> getAvailableAttendees(
+    Map<String, List<TimeRange>> mapOfPeopletoTimes, int start, int end, 
+    Set<String> attendees) {
+    Set<String> availableAttendees = new HashSet<String>();
+    attendees.stream().forEach(attendee -> {
+      List<TimeRange> unavailableTimes = mapOfPeopletoTimes.get(attendee);
+      while (!unavailableTimes.isEmpty() && 
+        unavailableTimes.get(0).end() < start) {
+        unavailableTimes.remove(0);
+      }
+      if (unavailableTimes.isEmpty() || unavailableTimes.get(0).start() >= end) {
+        availableAttendees.add(attendee);
+      }
+    });
+    return availableAttendees;
   }
 
-  /** 
-    * If possible, returns all possible time ranges in which the mandatory and 
-    * optional attendees of the requested meeting could meet for the requested 
-    * duration, without conflicting with any `events` that are already scheduled 
-    * for these attendees. If no times are possible that work for all the attendees,
-    * returns possible times such that all mandatory attendees and as many 
-    * optional antendees as possible can attend the meeting at these times. 
-    */
-  public Collection<TimeRange> query(Collection<Event> events, 
-    MeetingRequest request) {
-    Set<String> mandatoryAttendees = request.getAttendees().stream()
-      .collect(Collectors.toSet()); 
-    Set<String> optionalAttendees = request.getOptionalAttendees().stream()
-      .collect(Collectors.toSet());
-    Set<String> allAttendees = Sets.union(mandatoryAttendees, optionalAttendees);
-    
-    Collection<TimeRange> timesIncludingAllAttendees = getPossibleTimes(
-      events, allAttendees, request);
-    if (timesIncludingAllAttendees.isEmpty()) {
-      return getOptimalSubsetTimes(
-          mandatoryAttendees, optionalAttendees, events,request);
-    } else {
-      return timesIncludingAllAttendees; 
+
+  /**
+   * A comparator for sorting events by their start time in ascending order.
+   */
+  private static final Comparator<Event> ORDER_EVENT_BY_START = new Comparator<Event>() {
+    @Override
+    public int compare(Event a, Event b) {
+      return Long.compare(a.getWhen().start(), b.getWhen().start());
     }
+  };
+
+  /** 
+    * Returns a map of people to time ranges of events they are scheduled to 
+    * attend, where the events they are mapped to are ordered by event start 
+    * time, ascending. 
+    */
+  private Map<String, List<TimeRange>> mapPeopleToUnavailabeTImes(Collection<Event> events) {
+    Map<String, List<TimeRange>> peopleToEvents = new HashMap<String, List<TimeRange>>();
+    events.stream().sorted(ORDER_EVENT_BY_START).forEachOrdered(event -> {
+      event.getAttendees().stream().forEach(attendee -> {
+        if (peopleToEvents.containsKey(attendee)) {
+          peopleToEvents.get(attendee).add(event.getWhen());
+        } else {
+          List<TimeRange> eventsAttending = new LinkedList<TimeRange>();
+          eventsAttending.add(event.getWhen());
+          peopleToEvents.put(attendee, eventsAttending);
+        }
+      });
+    });
+    return peopleToEvents;
   }
 }

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -94,7 +94,7 @@ public final class FindMeetingQuery {
   private Collection<TimeRange> getOptimalSubsetTimes(
     Set<String> mandatoryAttendees, Set<String> optionalAttendees, 
     Collection<Event> events, MeetingRequest request) {
-    Map<String, List<TimeRange>> mapOfPeopleToTimes = mapPeopleToUnavailabeTImes(events);
+    Map<String, List<TimeRange>> mapOfPeopleToTimes = mapPeopleToUnavailabeTimes(events);
     List<TimeRange> mandatoryAttendeeAvailability = 
       getPossibleTimes(events, mandatoryAttendees, request);
     Set<String> mostOptionalAttendeesCanAttend = new HashSet<String>();
@@ -127,11 +127,11 @@ public final class FindMeetingQuery {
     * that finish before start. 
     */
   private Set<String> getAvailableAttendees(
-    Map<String, List<TimeRange>> mapOfPeopletoTimes, int start, int end, 
+    Map<String, List<TimeRange>> mapOfPeopleToTimes, int start, int end, 
     Set<String> attendees) {
     Set<String> availableAttendees = new HashSet<String>();
     attendees.stream().forEach(attendee -> {
-      List<TimeRange> unavailableTimes = mapOfPeopletoTimes.get(attendee);
+      List<TimeRange> unavailableTimes = mapOfPeopleToTimes.get(attendee);
       while (!unavailableTimes.isEmpty() && 
         unavailableTimes.get(0).end() < start) {
         unavailableTimes.remove(0);
@@ -159,7 +159,7 @@ public final class FindMeetingQuery {
     * attend, where the events they are mapped to are ordered by event start 
     * time, ascending. 
     */
-  private Map<String, List<TimeRange>> mapPeopleToUnavailabeTImes(Collection<Event> events) {
+  private Map<String, List<TimeRange>> mapPeopleToUnavailabeTimes(Collection<Event> events) {
     Map<String, List<TimeRange>> peopleToEvents = new HashMap<String, List<TimeRange>>();
     events.stream().sorted(ORDER_EVENT_BY_START).forEachOrdered(event -> {
       event.getAttendees().stream().forEach(attendee -> {

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -390,7 +390,7 @@ public final class FindMeetingQueryTest {
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
-        Arrays.asList(TimeRange.fromStartEnd(TIME_0900AM, TIME_1000AM));
+        Arrays.asList(TimeRange.fromStartEnd(TIME_0900AM, TIME_1000AM, false));
 
     Assert.assertEquals(expected, actual);
   }
@@ -410,7 +410,8 @@ public final class FindMeetingQueryTest {
             Arrays.asList(PERSON_A)),
         new Event("Event 2", TimeRange.fromStartEnd(TIME_1100AM, TimeRange.END_OF_DAY, true),
             Arrays.asList(PERSON_A)),
-        new Event("Event 3", TimeRange.fromStartEnd(TIME_0900AM,TIME_1100AM),
+        new Event("Event 3", TimeRange.fromStartEnd(TIME_0900AM,
+          TIME_1100AM, false),
             Arrays.asList(PERSON_B)));
 
     MeetingRequest request = new MeetingRequest(NO_ATTENDEES, DURATION_30_MINUTES);

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -402,7 +402,7 @@ public final class FindMeetingQueryTest {
     // nothing since no times work for anyone. 
     //
     // Events  : |----------A----------| (optional)
-    //           |----------B----------|
+    //           |----------B----------| (optional)
     // Day     : |---------------------|
     // Options :       
 

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -399,21 +399,16 @@ public final class FindMeetingQueryTest {
   @Test
   public void noMandatoryAttendeesAndNoPossibleTimes() {
     // All attendees for a meeting are optional. Should return
-    // the slot that works for both people.
+    // nothing since no times work for anyone. 
     //
-    // Events  : |--A--|         |--A--| (optional)
-    //                 |----B----|       (optional)
+    // Events  : |----------A----------| (optional)
+    //           |----------B----------|
     // Day     : |---------------------|
     // Options :       
 
     Collection<Event> events = Arrays.asList(
-        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0900AM, false),
-            Arrays.asList(PERSON_A)),
-        new Event("Event 2", TimeRange.fromStartEnd(TIME_1100AM, TimeRange.END_OF_DAY, true),
-            Arrays.asList(PERSON_A)),
-        new Event("Event 3", TimeRange.fromStartEnd(TIME_0900AM,
-          TIME_1100AM, false),
-            Arrays.asList(PERSON_B)));
+        new Event("Event 1", TimeRange.WHOLE_DAY, Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.WHOLE_DAY, Arrays.asList(PERSON_B)));
 
     MeetingRequest request = new MeetingRequest(NO_ATTENDEES, DURATION_30_MINUTES);
     request.addOptionalAttendee(PERSON_A);

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -34,6 +34,7 @@ public final class FindMeetingQueryTest {
   // Some people that we can use in our tests.
   private static final String PERSON_A = "Person A";
   private static final String PERSON_B = "Person B";
+  private static final String PERSON_C = "Person C";
 
   // All dates are the first day of the year 2020.
   private static final int TIME_0800AM = TimeRange.getTimeInMinutes(8, 0);
@@ -43,6 +44,7 @@ public final class FindMeetingQueryTest {
   private static final int TIME_1000AM = TimeRange.getTimeInMinutes(10, 0);
   private static final int TIME_1100AM = TimeRange.getTimeInMinutes(11, 00);
 
+  private static final int DURATION_15_MINUTES = 15;
   private static final int DURATION_30_MINUTES = 30;
   private static final int DURATION_60_MINUTES = 60;
   private static final int DURATION_90_MINUTES = 90;
@@ -270,5 +272,154 @@ public final class FindMeetingQueryTest {
 
     Assert.assertEquals(expected, actual);
   }
-}
 
+  @Test
+  public void optionalAttendeeIsConsidered() {
+    // Have optional attendee who can be scheduled block out
+    // slot that was possible for mandatory attendees. We should see
+    // only the options at the beginnning and end of the day. 
+    //
+    // Events  :       |--A--|     |--B--|
+    //                       |--C--|             (optional)
+    // Day     : |-----------------------------|
+    // Options : |--1--|                 |--2--|
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_B)),
+        new Event("Event 3", TimeRange.fromStartDuration(TIME_0830AM,
+          DURATION_30_MINUTES),
+            Arrays.asList(PERSON_C)));
+
+    MeetingRequest request =
+        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_C);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void infeasibleOptionalAttendeesAreNotScheduled() {
+    // Have an optional attendee that cannot be scheduled. We should see
+    // two options. 
+    //
+    // Events  :       |--A--|     |--B--|
+    //           |--------------C--------------| (optional)
+    // Day     : |-----------------------------|
+    // Options : |--1--|     |--2--|     |--3--|
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_B)),
+        new Event("Event 3", TimeRange.WHOLE_DAY, Arrays.asList(PERSON_C)));
+
+    MeetingRequest request =
+        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_C);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+            TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void notEnoughRoomForOptionalAttendee() {
+    // Have an optional attendee that makes the only available time 
+    // shorter than the required duration of the meeting. Optional
+    // attendee should be ignored. 
+    //
+    // Events  : |--A--|     |----A----|
+    //                 |-B-|             (optional)
+    // Day     : |---------------------|
+    // Options :       |-----|
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 3", TimeRange.fromStartDuration(TIME_0830AM,
+          DURATION_15_MINUTES),
+            Arrays.asList(PERSON_B)));
+
+    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_B);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void noMandatoryAttendees() {
+    // All attendees for a meeting are optional. Should return
+    // the slot that works for both people.
+    //
+    // Events  : |--A--|         |--A--| (optional)
+    //                     |--B--|       (optional)
+    // Day     : |---------------------|
+    // Options :       |---|
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0900AM, false),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartEnd(TIME_1100AM, TimeRange.END_OF_DAY, true),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 3", TimeRange.fromStartDuration(TIME_1000AM,
+          DURATION_60_MINUTES),
+            Arrays.asList(PERSON_B)));
+
+    MeetingRequest request = new MeetingRequest(NO_ATTENDEES, DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_A);
+    request.addOptionalAttendee(PERSON_B);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartEnd(TIME_0900AM, TIME_1000AM));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void noMandatoryAttendeesAndNoPossibleTimes() {
+    // All attendees for a meeting are optional. Should return
+    // the slot that works for both people.
+    //
+    // Events  : |--A--|         |--A--| (optional)
+    //                 |----B----|       (optional)
+    // Day     : |---------------------|
+    // Options :       
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0900AM, false),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartEnd(TIME_1100AM, TimeRange.END_OF_DAY, true),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 3", TimeRange.fromStartEnd(TIME_0900AM,TIME_1100AM),
+            Arrays.asList(PERSON_B)));
+
+    MeetingRequest request = new MeetingRequest(NO_ATTENDEES, DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_A);
+    request.addOptionalAttendee(PERSON_B);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected = Arrays.asList();
+
+    Assert.assertEquals(expected, actual);
+  }
+}


### PR DESCRIPTION
I wrote tests for and then implemented functionality such that if there are optional attendees and not all of them can be scheduled, the algorithm will choose times such that the maximum number of optional attendees can attend the meeting (as well as all the mandatory attendees). 